### PR TITLE
Gotos no longer recursive

### DIFF
--- a/interpret.py
+++ b/interpret.py
@@ -92,54 +92,6 @@ def parse(usrtask):
 		goToLine = int(tags[usrtask[1]])
 
 		currentLine = goToLine  # Change the line the interpreter will pass to the relevant tag
-
-	elif usrtask.startswith("if"):
-		tsk = usrtask.split(
-			" ")  # This will split up the arugments, however, this will also split any strings with spaces
-		tsk.pop(0)
-
-		validComparitors = [">", "<", "=="]
-
-		checkInts = [0, 2]  # This is there incase you add multiple variable checking later on
-		for asdf in checkInts:  # For every possible index for an argument
-			if tsk[asdf][0] == "$" or tsk[asdf][0] == "#":
-				tsk[asdf] = exec.usrvars[
-					tsk[asdf]]  # Make it so the interpreter is comparing the values, not the variable name
-
-		evaluation = False  # Weather or not the if statement is true
-
-		iii = 0  # Current index
-		for t in tsk:  # For every argument inside the if statement, This will make sure any strings that where split with the .split gets rejoined
-			try:
-				lst = tsk[iii + 1][-1:]
-				if t[0] == "\"" and lst == "\"":  # If its a string literal and the next value is also a string literal
-					tsk[iii] += tsk[iii + 1]  # Concatinate the two strings that would have split from the spaces
-					tsk.pop(iii + 1)
-			except IndexError:
-				pass
-			iii += 1
-
-		if tsk[1] == ">":  # Probaly more elagant way to do this but good enough...
-			if tsk[0] > tsk[2]:
-				evaluation = True
-		elif tsk[1] == "<":
-			if tsk[0] < tsk[2]:
-				evaluation = True
-		elif tsk[1] == "==":
-			if tsk[0] == tsk[2]:
-				evaluation = True
-
-		lastEvaluation = evaluation
-		if evaluation:
-			l = int(tags[tsk[3]])
-			currentLine = l
-	elif usrtask.startswith("else"):
-		if not tasks[currentLine - 1].startswith("if"):  # If the last line was not if
-			error.error("If statement expected")
-		if not lastEvaluation:  # If the last eval was true
-			usrtask = usrtask[5:]
-			l = int(tags[usrtask])
-			currentLine = l
 	elif usrtask == "END":
 		exit()
 

--- a/interpret.py
+++ b/interpret.py
@@ -34,11 +34,12 @@ for task in tasks:
 
 tasks.append("END")
 
+
 def parse(usrtask):
 	global prefixes
 	global currentLine
 	global lastEvaluation
-	
+
 	if usrtask.startswith("disp"):
 		exec.disp(usrtask.strip("disp ").strip('"'))
 
@@ -90,55 +91,60 @@ def parse(usrtask):
 		usrtask = usrtask.split(" ")
 		goToLine = int(tags[usrtask[1]])
 
-		currentLine = goToLine#Change the line the interpreter will pass to the relevant tag
-		
+		currentLine = goToLine  # Change the line the interpreter will pass to the relevant tag
+
 	elif usrtask.startswith("if"):
-		tsk = usrtask.split(" ")#This will split up the arugments, however, this will also split any strings with spaces
+		tsk = usrtask.split(
+			" ")  # This will split up the arugments, however, this will also split any strings with spaces
 		tsk.pop(0)
 
-		validComparitors = [">","<","=="]
+		validComparitors = [">", "<", "=="]
 
 		checkInts = [0, 2]  # This is there incase you add multiple variable checking later on
 		for asdf in checkInts:  # For every possible index for an argument
 			if tsk[asdf][0] == "$" or tsk[asdf][0] == "#":
-				tsk[asdf] = exec.usrvars[tsk[asdf]]  # Make it so the interpreter is comparing the values, not the variable name
+				tsk[asdf] = exec.usrvars[
+					tsk[asdf]]  # Make it so the interpreter is comparing the values, not the variable name
 
-		evaluation=False #Weather or not the if statement is true
+		evaluation = False  # Weather or not the if statement is true
 
-		iii = 0 #Current index
-		for t in tsk: #For every argument inside the if statement, This will make sure any strings that where split with the .split gets rejoined
+		iii = 0  # Current index
+		for t in tsk:  # For every argument inside the if statement, This will make sure any strings that where split with the .split gets rejoined
 			try:
-				lst = tsk[iii+1][-1:]
-				if t[0] == "\"" and lst == "\"": #If its a string literal and the next value is also a string literal
-					tsk[iii]+=tsk[iii+1] #Concatinate the two strings that would have split from the spaces
-					tsk.pop(iii+1)
+				lst = tsk[iii + 1][-1:]
+				if t[0] == "\"" and lst == "\"":  # If its a string literal and the next value is also a string literal
+					tsk[iii] += tsk[iii + 1]  # Concatinate the two strings that would have split from the spaces
+					tsk.pop(iii + 1)
 			except IndexError:
 				pass
-			iii+=1
+			iii += 1
 
-		if tsk[1] == ">":#Probaly more elagant way to do this but good enough...
+		if tsk[1] == ">":  # Probaly more elagant way to do this but good enough...
 			if tsk[0] > tsk[2]:
-				evaluation=True
+				evaluation = True
 		elif tsk[1] == "<":
 			if tsk[0] < tsk[2]:
-				evaluation=True
+				evaluation = True
 		elif tsk[1] == "==":
 			if tsk[0] == tsk[2]:
-				evaluation=True
+				evaluation = True
 
 		lastEvaluation = evaluation
 		if evaluation:
 			l = int(tags[tsk[3]])
 			currentLine = l
 	elif usrtask.startswith("else"):
-		if not tasks[currentLine-1].startswith("if"): #If the last line was not if
+		if not tasks[currentLine - 1].startswith("if"):  # If the last line was not if
 			error.error("If statement expected")
-		if not lastEvaluation: #If the last eval was true
+		if not lastEvaluation:  # If the last eval was true
 			usrtask = usrtask[5:]
-			l = int(tags[usrtask.split(" ")[1]])
+			l = int(tags[usrtask])
 			currentLine = l
 	elif usrtask == "END":
 		exit()
-currentLine = 0 #Reset to 0 so while loop starts from beggining
+
+
+currentLine = 0  # Reset to 0 so while loop starts from beggining
 while currentLine < len(tasks):
-	parse(tasks[currentLine)
+	parse(tasks[currentLine])
+	currentLine+=1

--- a/interpret.py
+++ b/interpret.py
@@ -8,7 +8,6 @@ import error
 tags = {}
 prefixes = ["$", "#"]
 currentLine = 0
-lastEvaluation = False
 
 args = sys.argv
 try:
@@ -38,7 +37,6 @@ tasks.append("END")
 def parse(usrtask):
 	global prefixes
 	global currentLine
-	global lastEvaluation
 
 	if usrtask.startswith("disp"):
 		exec.disp(usrtask.strip("disp ").strip('"'))

--- a/interpret.py
+++ b/interpret.py
@@ -8,6 +8,7 @@ import error
 tags = {}
 prefixes = ["$", "#"]
 currentLine = 0
+lastEvaluation = False
 
 args = sys.argv
 try:
@@ -35,7 +36,9 @@ tasks.append("END")
 
 def parse(usrtask):
 	global prefixes
-
+	global currentLine
+	global lastEvaluation
+	
 	if usrtask.startswith("disp"):
 		exec.disp(usrtask.strip("disp ").strip('"'))
 
@@ -87,11 +90,55 @@ def parse(usrtask):
 		usrtask = usrtask.split(" ")
 		goToLine = int(tags[usrtask[1]])
 
-		for task in tasks[goToLine:]:
-			parse(task)
+		currentLine = goToLine#Change the line the interpreter will pass to the relevant tag
+		
+	elif usrtask.startswith("if"):
+		tsk = usrtask.split(" ")#This will split up the arugments, however, this will also split any strings with spaces
+		tsk.pop(0)
 
+		validComparitors = [">","<","=="]
+
+		checkInts = [0, 2]  # This is there incase you add multiple variable checking later on
+		for asdf in checkInts:  # For every possible index for an argument
+			if tsk[asdf][0] == "$" or tsk[asdf][0] == "#":
+				tsk[asdf] = exec.usrvars[tsk[asdf]]  # Make it so the interpreter is comparing the values, not the variable name
+
+		evaluation=False #Weather or not the if statement is true
+
+		iii = 0 #Current index
+		for t in tsk: #For every argument inside the if statement, This will make sure any strings that where split with the .split gets rejoined
+			try:
+				lst = tsk[iii+1][-1:]
+				if t[0] == "\"" and lst == "\"": #If its a string literal and the next value is also a string literal
+					tsk[iii]+=tsk[iii+1] #Concatinate the two strings that would have split from the spaces
+					tsk.pop(iii+1)
+			except IndexError:
+				pass
+			iii+=1
+
+		if tsk[1] == ">":#Probaly more elagant way to do this but good enough...
+			if tsk[0] > tsk[2]:
+				evaluation=True
+		elif tsk[1] == "<":
+			if tsk[0] < tsk[2]:
+				evaluation=True
+		elif tsk[1] == "==":
+			if tsk[0] == tsk[2]:
+				evaluation=True
+
+		lastEvaluation = evaluation
+		if evaluation:
+			l = int(tags[tsk[3]])
+			currentLine = l
+	elif usrtask.startswith("else"):
+		if not tasks[currentLine-1].startswith("if"): #If the last line was not if
+			error.error("If statement expected")
+		if not lastEvaluation: #If the last eval was true
+			usrtask = usrtask[5:]
+			l = int(tags[usrtask.split(" ")[1]])
+			currentLine = l
 	elif usrtask == "END":
 		exit()
-
-for task in tasks:
-	parse(task)
+currentLine = 0 #Reset to 0 so while loop starts from beggining
+while currentLine < len(tasks):
+	parse(tasks[currentLine)


### PR DESCRIPTION
This modifies the code so that having goto doesn't cause the parse function to recurse. It changes the initial parse loop (line 143) from a for loop, to a while loop, this way you can modify the location where the interpreter is looking for code, allowing gotos to be non-recursive.

The if statement is quite messy, the first thing it does is split the line by spaces. This would be fine unless the user is comparing string literals with spaces, in which case the string literal gets split as well, there is a for loop later on that concatenates it (That for loop does not have to make sense, it works so it works.

The code then checks if the if statement compares variables, if it does, the variables will be replaced with the values of the variables. Finally, several if and elif statements check what type of if statement the user wants, and then sets evaluation variable based on that.

last evaluation is also set to globally track what the last if statement does, this is for the else statements later.

The else statement checks if the last statement was an if, it throws an error if not.

Then it checks the last evaluation variable set earlier, it true, it goes to the goto line.